### PR TITLE
11.0 delivery slip prices

### DIFF
--- a/delivery_slip_prices/__init__.py
+++ b/delivery_slip_prices/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+# from . import controllers
+# from . import models

--- a/delivery_slip_prices/__manifest__.py
+++ b/delivery_slip_prices/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Delivery Slip prices",
+
+    'summary': "Adding prices and totals to delivery slips",
+
+    'description': "Adding prices and totals to delivery slips",
+
+    'author': "Odoo",
+    'website': "http://www.odoo.com",
+
+    # Categories can be used to filter modules in modules listing
+    # Check https://github.com/odoo/odoo/blob/master/odoo/addons/base/module/module_data.xml
+    # for the full list
+    'category': 'Uncategorized',
+    'version': '0.1',
+
+    # any module necessary for this one to work correctly
+    'depends': ['stock'],
+
+    # always loaded
+    'data': [
+        'reports/delivery_slip.xml',
+    ],
+}

--- a/delivery_slip_prices/__manifest__.py
+++ b/delivery_slip_prices/__manifest__.py
@@ -16,7 +16,7 @@
     'version': '0.1',
 
     # any module necessary for this one to work correctly
-    'depends': ['stock'],
+    'depends': ['stock','sale_stock'],
 
     # always loaded
     'data': [

--- a/delivery_slip_prices/reports/delivery_slip.xml
+++ b/delivery_slip_prices/reports/delivery_slip.xml
@@ -25,7 +25,7 @@
             </td>
             <t t-set="sub_total" t-value="0.0"/>
             <t t-if="move.sale_line_id">
-                <t t-set="sub_total" t-value="move.sale_line_id.price_unit * move.product_uom_qty"/>
+                <t t-set="sub_total" t-value="move.sale_line_id.price_unit * move.reserved_availability"/>
             </t>
             <t t-set="price_total" t-value="price_total + sub_total"/>
             <td class="text-right">
@@ -81,6 +81,10 @@
                     </div>
                 </div>
             </div>
+        </xpath>
+
+        <xpath expr="//table[contains(@t-if,'o.state!=')]/tbody/tr/td/span[@t-field='move.product_uom_qty']" position="replace">
+            <span t-field="move.reserved_availability"/>            
         </xpath>
         
     </template>

--- a/delivery_slip_prices/reports/delivery_slip.xml
+++ b/delivery_slip_prices/reports/delivery_slip.xml
@@ -1,0 +1,71 @@
+<odoo>
+    <template id="x_report_delivery_slip" inherit_id="stock.report_delivery_document">
+        <xpath expr="//table[contains(@t-if,'o.state!=')]/thead/tr/th[last()]" position="after">
+            <th class="text-right"><strong>Price</strong></th>
+            <th class="text-right"><strong>Line Total</strong></th>
+        </xpath>
+        <xpath expr="//table[contains(@t-if,'o.state==')]/thead/tr/th[last()]" position="after">
+            <th class="text-right"><strong>Price</strong></th>
+            <th class="text-right"><strong>Line Total</strong></th>
+        </xpath>
+        <xpath expr="//table[contains(@t-if,'o.state!=')]" position="before">
+            <t t-set="price_total" t-value="0.0"/>
+        </xpath>
+        <xpath expr="//table[contains(@t-if,'o.state==')]" position="before">
+            <t t-set="price_total" t-value="0.0"/>
+        </xpath>
+        <xpath expr="//table[contains(@t-if,'o.state!=')]/tbody/tr/td[last()]" position="after">
+            <td class="text-right">
+                <span t-field="move.sale_line_id.price_unit"/>
+            </td>
+            <t t-set="sub_total" t-value="move.sale_line_id.price_unit * move.product_uom_qty"/>
+            <t t-set="price_total" t-value="price_total + sub_total"/>
+            <td class="text-right">
+                <span t-esc="sub_total"/>
+            </td>
+        </xpath>
+        <xpath expr="//table[contains(@t-if,'o.state==')]/tbody/tr/td[last()]" position="after">
+            <td class="text-right">
+                <span t-field="move_line.move_id.sale_line_id.price_unit"/>
+            </td>
+            <t t-set="sub_total" t-value="move_line.move_id.sale_line_id.price_unit * move_line.qty_done"/>
+            <t t-set="price_total" t-value="price_total + sub_total"/>
+            <td class="text-right">
+                <span t-esc="sub_total"/>
+            </td>
+        </xpath>
+        <xpath expr="//table[contains(@t-if,'o.state!=')]" position="after">
+            <div class="clearfix">
+                <div class="row" name="total">
+                    <div class="col-xs-4 pull-right">
+                        <table class="table table-condensed" style="min-width: 200px;max-width: 350px;" t-if="o.state!='done'">
+                            <tr class="border-black">
+                                <td class="text-right"><strong>Total</strong></td>
+                                <td class="text-right">
+                                    <span t-esc="price_total" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </xpath>
+        <xpath expr="//table[contains(@t-if,'o.state==')]" position="after">
+            <div class="clearfix">
+                <div class="row" name="total">
+                    <div class="col-xs-4 pull-right">
+                        <table class="table table-condensed" style="min-width: 200px;max-width: 350px;" t-if="o.move_line_ids and o.state=='done'">
+                            <tr class="border-black">
+                                <td class="text-right"><strong>Total</strong></td>
+                                <td class="text-right">
+                                    <span t-esc="price_total" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </xpath>
+        
+    </template>
+</odoo>

--- a/delivery_slip_prices/reports/delivery_slip.xml
+++ b/delivery_slip_prices/reports/delivery_slip.xml
@@ -25,7 +25,7 @@
             </td>
             <t t-set="sub_total" t-value="0.0"/>
             <t t-if="move.sale_line_id">
-                <t t-set="sub_total" t-value="move.sale_line_id.price_unit * move.reserved_availability"/>
+                <t t-set="sub_total" t-value="move.sale_line_id.price_unit / move.sale_line_id.product_uom.factor_inv * move.reserved_availability"/>
             </t>
             <t t-set="price_total" t-value="price_total + sub_total"/>
             <td class="text-right">
@@ -43,7 +43,7 @@
             </td>
             <t t-set="sub_total" t-value="0.0"/>
             <t t-if="move_line.move_id.sale_line_id">
-                <t t-set="sub_total" t-value="move_line.move_id.sale_line_id.price_unit * move_line.qty_done"/>
+                <t t-set="sub_total" t-value="move_line.move_id.sale_line_id.price_unit / move_line.move_id.sale_line_id.product_uom.factor_inv * move_line.qty_done"/>
             </t>
             <t t-set="price_total" t-value="price_total + sub_total"/>
             <td class="text-right">

--- a/delivery_slip_prices/reports/delivery_slip.xml
+++ b/delivery_slip_prices/reports/delivery_slip.xml
@@ -23,6 +23,7 @@
                     <span> No Sale Line ID associated with this stock picking</span>
                 </t>
             </td>
+            <t t-set="sub_total" t-value="0.0"/>
             <t t-if="move.sale_line_id">
                 <t t-set="sub_total" t-value="move.sale_line_id.price_unit * move.product_uom_qty"/>
             </t>
@@ -40,6 +41,7 @@
                     <span> No Sale Line ID associated with this stock picking</span>
                 </t>
             </td>
+            <t t-set="sub_total" t-value="0.0"/>
             <t t-if="move_line.move_id.sale_line_id">
                 <t t-set="sub_total" t-value="move_line.move_id.sale_line_id.price_unit * move_line.qty_done"/>
             </t>

--- a/delivery_slip_prices/reports/delivery_slip.xml
+++ b/delivery_slip_prices/reports/delivery_slip.xml
@@ -17,7 +17,7 @@
         <xpath expr="//table[contains(@t-if,'o.state!=')]/tbody/tr/td[last()]" position="after">
             <td class="text-right">
                 <t t-if="move.sale_line_id">
-                    <span t-field="move.sale_line_id.price_unit" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
+                    <span t-esc="move.sale_line_id.price_unit / move.sale_line_id.product_uom.factor_inv" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
                 </t>
                 <t t-else="">
                     <span> No Sale Line ID associated with this stock picking</span>
@@ -35,7 +35,7 @@
         <xpath expr="//table[contains(@t-if,'o.state==')]/tbody/tr/td[last()]" position="after">
             <td class="text-right">
                 <t t-if="move_line.move_id.sale_line_id">
-                    <span t-field="move_line.move_id.sale_line_id.price_unit" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
+                    <span t-esc="move_line.move_id.sale_line_id.price_unit / move_line.move_id.sale_line_id.product_uom.factor_inv" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
                 </t>
                 <t t-else="">
                     <span> No Sale Line ID associated with this stock picking</span>

--- a/delivery_slip_prices/reports/delivery_slip.xml
+++ b/delivery_slip_prices/reports/delivery_slip.xml
@@ -16,9 +16,16 @@
         </xpath>
         <xpath expr="//table[contains(@t-if,'o.state!=')]/tbody/tr/td[last()]" position="after">
             <td class="text-right">
-                <span t-field="move.sale_line_id.price_unit" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
+                <t t-if="move.sale_line_id">
+                    <span t-field="move.sale_line_id.price_unit" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
+                </t>
+                <t t-else="">
+                    <span> No Sale Line ID associated with this stock picking</span>
+                </t>
             </td>
-            <t t-set="sub_total" t-value="move.sale_line_id.price_unit * move.product_uom_qty"/>
+            <t t-if="move.sale_line_id">
+                <t t-set="sub_total" t-value="move.sale_line_id.price_unit * move.product_uom_qty"/>
+            </t>
             <t t-set="price_total" t-value="price_total + sub_total"/>
             <td class="text-right">
                 <span t-esc="sub_total" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
@@ -26,9 +33,16 @@
         </xpath>
         <xpath expr="//table[contains(@t-if,'o.state==')]/tbody/tr/td[last()]" position="after">
             <td class="text-right">
-                <span t-field="move_line.move_id.sale_line_id.price_unit" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
+                <t t-if="move_line.move_id.sale_line_id">
+                    <span t-field="move_line.move_id.sale_line_id.price_unit" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
+                </t>
+                <t t-else="">
+                    <span> No Sale Line ID associated with this stock picking</span>
+                </t>
             </td>
-            <t t-set="sub_total" t-value="move_line.move_id.sale_line_id.price_unit * move_line.qty_done"/>
+            <t t-if="move_line.move_id.sale_line_id">
+                <t t-set="sub_total" t-value="move_line.move_id.sale_line_id.price_unit * move_line.qty_done"/>
+            </t>
             <t t-set="price_total" t-value="price_total + sub_total"/>
             <td class="text-right">
                 <span t-esc="sub_total" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>

--- a/delivery_slip_prices/reports/delivery_slip.xml
+++ b/delivery_slip_prices/reports/delivery_slip.xml
@@ -16,22 +16,22 @@
         </xpath>
         <xpath expr="//table[contains(@t-if,'o.state!=')]/tbody/tr/td[last()]" position="after">
             <td class="text-right">
-                <span t-field="move.sale_line_id.price_unit"/>
+                <span t-field="move.sale_line_id.price_unit" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
             </td>
             <t t-set="sub_total" t-value="move.sale_line_id.price_unit * move.product_uom_qty"/>
             <t t-set="price_total" t-value="price_total + sub_total"/>
             <td class="text-right">
-                <span t-esc="sub_total"/>
+                <span t-esc="sub_total" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
             </td>
         </xpath>
         <xpath expr="//table[contains(@t-if,'o.state==')]/tbody/tr/td[last()]" position="after">
             <td class="text-right">
-                <span t-field="move_line.move_id.sale_line_id.price_unit"/>
+                <span t-field="move_line.move_id.sale_line_id.price_unit" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
             </td>
             <t t-set="sub_total" t-value="move_line.move_id.sale_line_id.price_unit * move_line.qty_done"/>
             <t t-set="price_total" t-value="price_total + sub_total"/>
             <td class="text-right">
-                <span t-esc="sub_total"/>
+                <span t-esc="sub_total" t-options='{"widget": "monetary", "display_currency": o.sale_id.currency_id}'/>
             </td>
         </xpath>
         <xpath expr="//table[contains(@t-if,'o.state!=')]" position="after">

--- a/farmproject_inventory/__init__.py
+++ b/farmproject_inventory/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models

--- a/farmproject_inventory/__manifest__.py
+++ b/farmproject_inventory/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    "name": "The Farm Project: Purchase Inventory Customizations",
+    'summary': "Web",
+    'description': """
+The Farm Project: Purchase Inventory Customizations
+===================================================
+- Quantities in purchase unit of measures on incoming shipments.
+""",
+    "author": "Odoo Inc",
+    'website': "https://www.odoo.com",
+    'category': 'Custom Development',
+    'version': '0.1',
+    'depends': ['stock', 'purchase'],
+    'data': [
+        'views/stock_picking_views.xml',
+    ],
+    'license': 'OEEL-1',
+}

--- a/farmproject_inventory/models/__init__.py
+++ b/farmproject_inventory/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import stock_move

--- a/farmproject_inventory/models/stock_move.py
+++ b/farmproject_inventory/models/stock_move.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, fields, models
+from odoo.tools.float_utils import float_is_zero, float_compare
+from odoo.addons import decimal_precision as dp
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    purchase_uom = fields.Many2one(comodel_name="product.uom", compute='_compute_product_uom', string="Unit of Measure")
+    product_uom_po_qty = fields.Float(string="Initial Demand", compute="_compute_product_uom_po_qty", digits=dp.get_precision('Product Unit of Measure'), inverse="_product_uom_qty_set")
+    po_qty_done = fields.Float(compute="_quantity_done_compute", string="Done", inverse="_po_qty_done_set", digits=dp.get_precision('Product Unit of Measure'))
+
+    @api.depends('picking_code')
+    def _compute_product_uom(self):
+        for move in self:
+            move.purchase_uom = move.product_id.uom_po_id if move.picking_code == 'incoming' else move.product_id.uom_id
+
+    @api.multi
+    def _compute_product_uom_po_qty(self):
+        for move in self:
+            move.product_uom_po_qty = move.product_uom._compute_quantity(move.product_uom_qty, move.product_id.uom_po_id, rounding_method='HALF-UP') if move.picking_code == 'incoming' else move.product_uom_qty
+
+    def _product_uom_qty_set(self):
+        for move in self:
+            if move.product_uom_po_qty:
+                move.product_uom_qty = move.purchase_uom._compute_quantity(move.product_uom_po_qty, move.product_uom, rounding_method='HALF-UP')
+
+    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
+        vals = super(StockMove, self)._prepare_move_line_vals(quantity=quantity, reserved_quant=reserved_quant)
+        if quantity and self.picking_code == 'incoming':
+            uom_po_quantity = self.product_id.uom_id._compute_quantity(quantity, self.purchase_uom, rounding_method='HALF-UP')
+            uom_quantity_back_to_product_uom = self.purchase_uom._compute_quantity(uom_po_quantity, self.product_id.uom_id, rounding_method='HALF-UP')
+            rounding = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+            if float_compare(quantity, uom_quantity_back_to_product_uom, precision_digits=rounding) == 0:
+                vals = dict(vals, product_uom_qty=uom_po_quantity, product_uom_id=self.purchase_uom.id)
+            else:
+                vals = dict(vals, product_uom_qty=quantity, product_uom_id=self.purchase_uom.id)
+        return vals
+
+    @api.depends('move_line_ids.qty_done', 'move_line_ids.product_uom_id', 'move_line_nosuggest_ids.qty_done')
+    def _quantity_done_compute(self):
+        """ This field represents the sum of the move lines `qty_done`. It allows the user to know
+        if there is still work to do.
+
+        We take care of rounding this value at the general decimal precision and not the rounding
+        of the move's UOM to make sure this value is really close to the real sum, because this
+        field will be used in `_action_done` in order to know if the move will need a backorder or
+        an extra move.
+        """
+        for move in self:
+            quantity_done = qty_po_done = 0
+            for move_line in move._get_move_lines():
+                quantity_done += move_line.product_uom_id._compute_quantity(move_line.qty_done, move.product_uom, round=False)
+                qty_po_done += move_line.product_uom_id._compute_quantity(move_line.qty_done, move.purchase_uom, round=False)
+            move.quantity_done = quantity_done
+            move.po_qty_done = qty_po_done
+
+    def _po_qty_done_set(self):
+        self[0].quantity_done = self[0].po_qty_done
+        self._quantity_done_set()

--- a/farmproject_inventory/views/stock_picking_views.xml
+++ b/farmproject_inventory/views/stock_picking_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+	<record id="stock_picking_form_inherit_farmproject_inventory" model="ir.ui.view">
+	    <field name="name">stock.picking.form.inherit.farmproject_inventory</field>
+	    <field name="model">stock.picking</field>
+	    <field name="inherit_id" ref="stock.view_picking_form"/>
+	    <field name="arch" type="xml">
+	    	<xpath expr="//field[@name='move_lines']/tree//field[@name='product_uom']" position="replace">
+	    		<field name="purchase_uom" readonly="1"/>
+	    	</xpath>
+	    	<xpath expr="//field[@name='move_lines']/tree//field[@name='product_uom_qty']" position="replace">
+	    		<field name="product_uom_po_qty"/>
+	    	</xpath>
+	    	<xpath expr="//field[@name='move_lines']/tree//field[@name='quantity_done']" position="after">
+	    		<field name="po_qty_done"/>
+	    	</xpath>
+	    	<xpath expr="//field[@name='move_lines']/tree//field[@name='quantity_done']" position="attributes">
+	    		<attribute name="invisible">True</attribute>
+	    	</xpath>
+	    </field>
+	</record>
+</odoo>


### PR DESCRIPTION

We need the Delivery slip to have pricing information on it. The client will use the printed PDF as a delivery contract to sign by the client. In order for this to work, we need the price info and totals to be transferred to the PDF.

=> Attached is a mock-up of the required result with an explanation of each field

=> You will notice we are not referring to any fields, line totals or sub totals for taxes. They do not ever charge taxes to customers, so this can be ignored.